### PR TITLE
Feature/get user point history

### DIFF
--- a/src/main/java/io/hhplus/tdd/point/PointController.java
+++ b/src/main/java/io/hhplus/tdd/point/PointController.java
@@ -29,13 +29,15 @@ public class PointController {
     }
 
     /**
-     * TODO - 특정 유저의 포인트 충전/이용 내역을 조회하는 기능을 작성해주세요.
+     * 유저 포인트 내역을 조회한다.
+     * @param id
+     * @return List<PointHistory>
      */
     @GetMapping("{id}/histories")
     public List<PointHistory> history(
             @PathVariable long id
     ) {
-        return List.of();
+        return pointService.getUserPointHistories(id);
     }
 
     /**

--- a/src/main/java/io/hhplus/tdd/point/PointService.java
+++ b/src/main/java/io/hhplus/tdd/point/PointService.java
@@ -1,13 +1,17 @@
 package io.hhplus.tdd.point;
 
 import io.hhplus.tdd.database.UserPointTable;
+import io.hhplus.tdd.database.PointHistoryTable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class PointService {
     private final UserPointTable userPointTable;
+    private final PointHistoryTable pointHistoryTable;
 
     /**
      * 사용자의 포인트 정보를 조회합니다.
@@ -16,6 +20,15 @@ public class PointService {
      */
     public UserPoint getUserPoint(final long userId) {
         return userPointTable.selectById(userId);
+    }
+
+    /**
+     * 사용자의 포인트 내역을 조회합니다.
+     * @param userId
+     * @return List<PointHistory>
+     */
+    public List<PointHistory> getUserPointHistories(final long userId) {
+        return pointHistoryTable.selectAllByUserId(userId);
     }
 
 }

--- a/src/test/java/io/hhplus/tdd/point/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/point/PointServiceTest.java
@@ -1,5 +1,6 @@
 package io.hhplus.tdd.point;
 
+import io.hhplus.tdd.database.PointHistoryTable;
 import io.hhplus.tdd.database.UserPointTable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -7,6 +8,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -17,6 +20,9 @@ public class PointServiceTest {
 
     @Mock
     private UserPointTable userPointTable;
+
+    @Mock
+    private PointHistoryTable pointHistoryTable;
 
     @InjectMocks
     private PointService pointService;
@@ -35,6 +41,25 @@ public class PointServiceTest {
         // then
         assertThat(result.point()).isEqualTo(100L);
         then(userPointTable).should().selectById(userId);
+    }
+
+    @Test
+    void shouldReturnPointHistoryForUser() {
+        // given
+        long userId = 1L;
+        List<PointHistory> expectedHistories = List.of(
+                new PointHistory(1L, userId, 100L, TransactionType.CHARGE, System.currentTimeMillis()),
+                new PointHistory(2L, userId, -50L, TransactionType.USE, System.currentTimeMillis())
+        );
+        given(pointHistoryTable.selectAllByUserId(userId)).willReturn(expectedHistories);
+
+        // when
+        List<PointHistory> histories = pointService.getUserPointHistories(userId);
+
+        // then
+        assertThat(histories).hasSize(2);
+        assertThat(histories).isEqualTo(expectedHistories);
+        then(pointHistoryTable).should().selectAllByUserId(userId);
     }
 
 }


### PR DESCRIPTION
### 관련 이슈
[#2 ] 포인트 내역을 조회한다 

### 변경 내용
1. 포인트 내역 조회하는 서비스 레이어 단위 테스트 코드를 작성하였습니다.
2. `PointService`에 `userPointHistoryTable`로부터 포인트 내역을 조회하는 메서드를 작성하였습니다.
3. `PointController`에 회원의 포인트 내역을 조회하는 API EndPoint를 작성하였습니다.
4. 포인트 내역 조회 통합 테스트를 `PointControllerTest`에 작성하였습니다. 




closes #2 